### PR TITLE
Add IAM policy permissions for organizations:DescribeCreateAccountStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.1.0
+    
+**Commit Delta**: [Change from 0.0.0 release](https://github.com/plus3it/terraform-aws-org-new-account-iam-role/compare/0.0.0...0.1.0)
+
+**Released**: 2021.04.06
+
+**Summary**:
+        
+*   Updated the Terraform configuration to add the policy document to
+    provide the Lambda with permissions for 
+    organizations:DescribeCreateAccountStatus.
+*   Modified the unit tests to replace the monkeypatched function for
+    get_account_id with a call to moto organizations service to set up an 
+    obtain an organizations account ID.
+
 ### 0.0.0
 
 **Commit Delta**: N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-### 0.1.0
+### unreleased
     
-**Commit Delta**: [Change from 0.0.0 release](https://github.com/plus3it/terraform-aws-org-new-account-iam-role/compare/0.0.0...0.1.0)
+**Commit Delta**: [Change from 0.0.0 release](https://github.com/plus3it/terraform-aws-org-new-account-iam-role/compare/0.0.0...unreleased)
 
-**Released**: 2021.04.06
+**Released**: tbd
 
 **Summary**:
         

--- a/lambda/tests/requirements_dev.txt
+++ b/lambda/tests/requirements_dev.txt
@@ -1,2 +1,2 @@
 moto==2.0.4
-pytest==6.2.2
+pytest==6.2.3

--- a/main.tf
+++ b/main.tf
@@ -7,12 +7,28 @@ locals {
   name = "new_account_support_case_${random_string.id.result}"
 }
 
+
+data "aws_partition" "current" {}
+
+data "aws_iam_policy_document" "lambda" {
+  statement {
+    actions = [
+      "organizations:DescribeCreateAccountStatus"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
 module "lambda" {
   source = "git::https://github.com/plus3it/terraform-aws-lambda.git?ref=v1.2.0"
 
   function_name = local.name
   description   = "Create new IAM Account Role"
   handler       = "new_account_support_case.lambda_handler"
+  policy        = data.aws_iam_policy_document.lambda
   runtime       = "python3.8"
   source_path   = "${path.module}/lambda/src"
   timeout       = 300

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,9 @@ data "aws_partition" "current" {}
 data "aws_iam_policy_document" "lambda" {
   statement {
     actions = [
-      "organizations:DescribeCreateAccountStatus"
+      "organizations:DescribeCreateAccountStatus",
+      "support:CreateCase",
+      "support:DescribeCase"
     ]
 
     resources = [

--- a/tests/requirements_test.txt
+++ b/tests/requirements_test.txt
@@ -1,3 +1,3 @@
 tftest==1.5.4
-pytest==6.2.2
+pytest==6.2.3
 localstack-client==1.14

--- a/tests/test_terraform_install.py
+++ b/tests/test_terraform_install.py
@@ -6,6 +6,7 @@ Verifies the Terraform configuration by:
     - verifying a "dry run" of the lambda is successful,
     - executing the lambda to verify the libraries are installed.
 """
+from datetime import datetime
 import json
 import os
 from pathlib import Path
@@ -40,6 +41,30 @@ def config_path():
 def localstack_session():
     """Return a LocalStack client session."""
     return localstack_client.session.Session()
+
+
+@pytest.fixture(scope="module")
+def mock_event():
+    """Create an event used as an argument to the Lambda handler."""
+    return {
+        "version": "0",
+        "id": str(uuid.uuid4()),
+        "detail-type": "AWS API Call via CloudTrail",
+        "source": "aws.organizations",
+        "account": "222222222222",
+        "time": datetime.now().isoformat(),
+        "region": "us-east-1",
+        "resources": [],
+        "detail": {
+            "eventName": "CreateAccount",
+            "eventSource": "organizations.amazonaws.com",
+            "responseElements": {
+                "createAccountStatus": {
+                    "id": "car-123456789",
+                }
+            },
+        },
+    }
 
 
 @pytest.fixture(scope="module")
@@ -112,38 +137,19 @@ def test_lambda_dry_run(tf_output, localstack_session):
     assert response["StatusCode"] == 204
 
 
-def test_lambda_invocation(tf_output, localstack_session):
+def test_lambda_invocation(tf_output, localstack_session, mock_event):
     """Verify a support case was created."""
-    # The following event does not have a valid ID, so the lambda invocation
+    # The event does not have a valid ID, so the lambda invocation
     # will fail.  However, when it fails, an InvocationException (or
     # InvalidInputException when using AWS) should be raised.  This proves
     # the lambda and the AWS powertools library are installed.  (The AWS
     # powertools library is invoked to log exceptions.)
-    event = {
-        "version": "0",
-        "id": str(uuid.uuid4()),
-        "detail-type": "AWS API Call via CloudTrail",
-        "source": "aws.organizations",
-        "account": "222222222222",
-        "time": "2021-02-08T16:08:43Z",
-        "region": "us-east-1",
-        "resources": [],
-        "detail": {
-            "eventName": "CreateAccount",
-            "eventSource": "organizations.amazonaws.com",
-            "responseElements": {
-                "createAccountStatus": {
-                    "id": "xxx-11111111111111111111111111111111",
-                }
-            },
-        },
-    }
     lambda_client = localstack_session.client("lambda", region_name=AWS_DEFAULT_REGION)
     lambda_module = tf_output["lambda"]
     response = lambda_client.invoke(
         FunctionName=lambda_module["function_name"],
         InvocationType="RequestResponse",
-        Payload=json.dumps(event),
+        Payload=json.dumps(mock_event),
     )
     assert response["StatusCode"] == 200
 


### PR DESCRIPTION
Also:

- Replaced monkeypatched get_account_id() with a call to create an organization and an account within that org.  Used the ID
  for that account in the mocked event.
- Use monkeypatch envvars so envvars are appropriately set or cleared between tests.
- Updated versions for requirements.