### PR TITLE
Generalize support case variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 **Summary**:
         
+*   Add two more environment variables for Lambda:  SUBJECT and
+    COMMUNICATION_BODY.  Permit the variable 'account_id' to be used within 
+    the text of those two new environment variables.
 *   Updated the Terraform configuration to add the policy document to
     provide the Lambda with permissions for 
     organizations:DescribeCreateAccountStatus.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ make localstack/clean
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | cc\_list | Comma-separated list of email addresses to CC on this case.  At least one email address is required. | `string` | n/a | yes |
-| company\_name | Name of company requesting Enterprise Support of a new account. | `string` | n/a | yes |
+| communication\_body | Text for body of the email sent to support.  The variable 'account\_id' can be used within the text if preceded by a dollar sign and optionally enclosed by curly braces. | `string` | n/a | yes |
+| subject | Text for 'Subject' field of the email sent to support.  The variable 'account\_id' can be used within the text if preceded by a dollar sign and optionally enclosed by curly braces. | `string` | n/a | yes |
 | log\_level | Log level of the lambda output, one of: debug, info, warning, error, critical | `string` | `"info"` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ make localstack/clean
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | cc\_list | Comma-separated list of email addresses to CC on this case.  At least one email address is required. | `string` | n/a | yes |
-| communication\_body | Text for body of the email sent to support.  The variable 'account\_id' can be used within the text if preceded by a dollar sign and optionally enclosed by curly braces. | `string` | n/a | yes |
-| subject | Text for 'Subject' field of the email sent to support.  The variable 'account\_id' can be used within the text if preceded by a dollar sign and optionally enclosed by curly braces. | `string` | n/a | yes |
+| communication\_body | Text for body of the communication sent to support.  The variable 'account\_id' can be used within the text if preceded by a dollar sign and optionally enclosed by curly braces. | `string` | n/a | yes |
+| subject | Text for 'Subject' field of the communication sent to support.  The variable 'account\_id' can be used within the text if preceded by a dollar sign and optionally enclosed by curly braces. | `string` | n/a | yes |
 | log\_level | Log level of the lambda output, one of: debug, info, warning, error, critical | `string` | `"info"` | no |
 
 ## Outputs

--- a/lambda/src/new_account_support_case.py
+++ b/lambda/src/new_account_support_case.py
@@ -211,13 +211,13 @@ Enable Enterprise support for a new account.
 NOTE:  Use the environment variable 'LOG_LEVEL' to set the desired log level
 ('error', 'warning', 'info' or 'debug').  The default level is 'info'.""",
         )
-        parser.add_argument_group(
+        parser.add_argument(
             "--subject",
             required=True,
             type=str,
             help="Text for 'Subject' field of the communication sent to support.",
         )
-        parser.add_argument_group(
+        parser.add_argument(
             "--communication_body",
             required=True,
             type=str,

--- a/lambda/src/new_account_support_case.py
+++ b/lambda/src/new_account_support_case.py
@@ -89,13 +89,12 @@ class SupportCaseError(Exception):
 
 def template_to_string(template, account_id):
     """Replace account_id variable in string with actual value."""
-    if "$account_id" in template or "${account_id}" in template:
-        try:
-            return Template(template).substitute(account_id=account_id)
-        except KeyError as err:
-            raise SupportCaseError(
-                f"Unexpected variable '{err}' found in '{template}'"
-            ) from err
+    try:
+        return Template(template).substitute(account_id=account_id)
+    except KeyError as err:
+        raise SupportCaseError(
+            f"Unexpected variable {err} found in '{template}'"
+        ) from err
     return template
 
 
@@ -191,7 +190,7 @@ def lambda_handler(event, context):  # pylint: disable=unused-argument
 
     try:
         main(account_id, cc_list, subject, communication_body)
-    except SupportCaseInvalidArgumentsError as err:
+    except (SupportCaseInvalidArgumentsError, SupportCaseError) as err:
         LOG.error({"failure": err})
         raise
     except Exception:

--- a/lambda/src/new_account_support_case.py
+++ b/lambda/src/new_account_support_case.py
@@ -167,7 +167,7 @@ def lambda_handler(event, context):  # pylint: disable=unused-argument
     if not subject:
         msg = (
             "Environment variable 'SUBJECT' must provide the 'Subject' text "
-            "for the email sent to support."
+            "for the communication sent to support."
         )
         LOG.error(msg)
         raise SupportCaseInvalidArgumentsError(msg)
@@ -175,7 +175,7 @@ def lambda_handler(event, context):  # pylint: disable=unused-argument
     if not communication_body:
         msg = (
             "Environment variable 'COMMUNICATION_BODY' must provide the "
-            "body of the email sent to support."
+            "body of the communication sent to support."
         )
         LOG.error(msg)
         raise SupportCaseInvalidArgumentsError(msg)
@@ -215,13 +215,13 @@ NOTE:  Use the environment variable 'LOG_LEVEL' to set the desired log level
             "--subject",
             required=True,
             type=str,
-            help="Text for 'Subject' field of the email sent to support.",
+            help="Text for 'Subject' field of the communication sent to support.",
         )
         parser.add_argument_group(
             "--communication_body",
             required=True,
             type=str,
-            help="Text for body of the email sent to support.",
+            help="Text for body of the communication sent to support.",
         )
         parser.add_argument(
             "--cc_list",

--- a/lambda/src/requirements.txt
+++ b/lambda/src/requirements.txt
@@ -1,2 +1,2 @@
 aws-lambda-powertools==1.13.0
-boto3==1.17.44
+boto3==1.17.45

--- a/lambda/tests/test_new_account_support_case.py
+++ b/lambda/tests/test_new_account_support_case.py
@@ -178,7 +178,7 @@ def test_lambda_handler_missing_subject(lambda_context, monkeypatch, mock_event)
         lambda_func.lambda_handler(mock_event, lambda_context)
     assert (
         "Environment variable 'SUBJECT' must provide the 'Subject' text for "
-        "the email sent to support"
+        "the communication sent to support"
     ) in str(exc.value)
 
 
@@ -193,7 +193,7 @@ def test_lambda_handler_missing_communication_body(
         lambda_func.lambda_handler(mock_event, lambda_context)
     assert (
         "Environment variable 'COMMUNICATION_BODY' must provide the body of "
-        "the email sent to support"
+        "the communication sent to support"
     ) in str(exc.value)
 
 

--- a/main.tf
+++ b/main.tf
@@ -37,9 +37,10 @@ module "lambda" {
 
   environment = {
     variables = {
-      COMPANY_NAME = var.company_name
-      CC_LIST      = var.cc_list
-      LOG_LEVEL    = var.log_level
+      CC_LIST            = var.cc_list
+      COMMUNICATION_BODY = var.communication_body
+      LOG_LEVEL          = var.log_level
+      SUBJECT            = var.subject
     }
   }
 }

--- a/tests/test_terraform_install.py
+++ b/tests/test_terraform_install.py
@@ -86,8 +86,9 @@ def tf_output(config_path):
     tf_test.setup(extra_files=[str(Path(Path.cwd() / "tests" / "localstack.tf"))])
 
     tf_vars = {
-        "company_name": "Acme",
         "cc_list": "foo.com,bar.com",
+        "subject": "Add a new account for Acme",
+        "communication_body": "Please add this account to Enterprise support",
     }
 
     try:

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@ variable "cc_list" {
   type        = string
 }
 variable "communication_body" {
-  description = "Text for body of the email sent to support.  The variable 'account_id' can be used within the text if preceded by a dollar sign and optionally enclosed by curly braces."
+  description = "Text for body of the communication sent to support.  The variable 'account_id' can be used within the text if preceded by a dollar sign and optionally enclosed by curly braces."
   type        = string
 }
 variable "log_level" {
@@ -12,6 +12,6 @@ variable "log_level" {
   type        = string
 }
 variable "subject" {
-  description = "Text for 'Subject' field of the email sent to support.  The variable 'account_id' can be used within the text if preceded by a dollar sign and optionally enclosed by curly braces."
+  description = "Text for 'Subject' field of the communication sent to support.  The variable 'account_id' can be used within the text if preceded by a dollar sign and optionally enclosed by curly braces."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,13 +1,17 @@
-variable "company_name" {
-  description = "Name of company requesting Enterprise Support of a new account."
-  type        = string
-}
 variable "cc_list" {
   description = "Comma-separated list of email addresses to CC on this case.  At least one email address is required."
+  type        = string
+}
+variable "communication_body" {
+  description = "Text for body of the email sent to support.  The variable 'account_id' can be used within the text if preceded by a dollar sign and optionally enclosed by curly braces."
   type        = string
 }
 variable "log_level" {
   default     = "info"
   description = "Log level of the lambda output, one of: debug, info, warning, error, critical"
+  type        = string
+}
+variable "subject" {
+  description = "Text for 'Subject' field of the email sent to support.  The variable 'account_id' can be used within the text if preceded by a dollar sign and optionally enclosed by curly braces."
   type        = string
 }


### PR DESCRIPTION
This change removes the hard-coded values for the "subject" and "communication_body" of the message sent to the support group.  The changes can be summarized as follows:

- The "company_name" envvar was removed.
- The envvars "subject" and "communication_body" were added.
- The variable "account_id can be added to the "subject" and "communication_body" envvars.