### PR TITLE
Incorporates all updates for org-new-account lambda modules

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.2
+current_version = 1.0.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: terraform
+  directory: "/tests/test_create_package_separately"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,10 @@
 tardigrade-ci/
 .tardigrade-ci
 
-# terratest packaging
-tests/go.*
-
 # python cache
 __pycache__
 .python-version
+.pytest_cache
+
+# lambda builds
+builds/

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,7 @@ jobs:
           (set -x; git tag -a $RELEASE_VERSION -m $RELEASE_VERSION)
       deploy:
         provider: releases
-        api_key:
-          secure: HuGP8E/Mh4IfQg08ot++SfZPb5ydFtkRJ0fOQAL92hZJgqxODT4eqFQhGFd5OjNfRgBDuEIvU4E0NrE7a87yDXcz/56h3rdzXjtNIFTzFSg015Ult4i8ponU6PNqY8fQ9Zc908GQRviA9X8HHYK/HgoFir59a0CWg4LRf/AbO5XPlWtJlgTpPmt1nuoabwOhermx0dkrAlkVzLKFNDjAaAHQmoQAqVNQM1PZmkl7illAHcW8M47nKQApp4uNjCFz5wX8gcfLTG9hnBU93kZM70mLJjBJxcwnqCUScX46JPBQqXYSlii6OSXg3xyMOa0ThYFEBrb9KReKUmlcowEE0g/cQaazIOQZTxmnPqSX7X7vhZykfloTO1UIzmI3chvHKxN0rzaCLXvypGcgcAYarCsBEqHuaPAToerL6rFiRRB3W9xgw4r51NQTXDAmYKKKvnkMfP3OSnwRAqJu4XtWJFdqQ6Y0oXxE92MUAqJWP6s9Tbq4L2anU91fJpJwvqlA90MmGsciwXGQbRL1JsIGG3OP4uw7/7QLkQA6Hp/nGaQOw3RxaF/u0qKkVGHE0BewDq4JrRXNQvmm01eEiDpoYB2zyWlQbCUPfIy8tCFy+DLeq23wNObAeTSSJjGnJ/eG0Sz+FpL4+dLzI1y35HSEuEuFHgPXuGLdocTbYh1wyZ4=
+        api_key: $GH_RELEASES_TOKEN
         name: $RELEASE_VERSION
         body: $RELEASE_BODY
         tag_name: $RELEASE_VERSION

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 1.0.0
+
+**Commit Delta**: [Change from 0.2.2 release](https://github.com/plus3it/terraform-aws-org-new-account-support-case/compare/0.2.2...1.0.0)
+
+**Released**: 2022.11.09
+
+**Summary**:
+
+*   Simplifies exception handling with a global handler that logs all exceptions
+*   Improves event pattern to eliminate loop/wait logic in lambda function.
+*   Separates the CreateAccountResult and InviteAccountToOrganization patterns into two event rules.
+*   Changed lambda module to one published by terraform-aws-modules, for better long-term support
+*   Exposed new `lambda` variable that wraps arguments for the upstream lambda module
+*   Added support for creating multiple instances of this module. This achieved by either:
+    *   Tailoring the artifact location, by setting `lambda.artifacts_dir` to a different location for each instance
+    *   Creating the package separately from the lambda functions, see `tests/test_create_package_separately` for an example
+
 ### 0.2.2
 
 **Commit Delta**: [Change from 0.2.1 release](https://github.com/plus3it/terraform-aws-org-new-account-support-case/compare/0.2.1...0.2.2)

--- a/README.md
+++ b/README.md
@@ -33,13 +33,17 @@ make mockstack/clean
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
+| <a name="requirement_external"></a> [external](#requirement\_external) | >= 1.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Resources
@@ -56,6 +60,8 @@ make mockstack/clean
 | <a name="input_cc_list"></a> [cc\_list](#input\_cc\_list) | Comma-separated list of email addresses to CC on this case.  At least one email address is required. | `string` | n/a | yes |
 | <a name="input_communication_body"></a> [communication\_body](#input\_communication\_body) | Text for body of the communication sent to support.  The variable 'account\_id' can be used within the text if preceded by a dollar sign and optionally enclosed by curly braces. | `string` | n/a | yes |
 | <a name="input_subject"></a> [subject](#input\_subject) | Text for 'Subject' field of the communication sent to support.  The variable 'account\_id' can be used within the text if preceded by a dollar sign and optionally enclosed by curly braces. | `string` | n/a | yes |
+| <a name="input_event_types"></a> [event\_types](#input\_event\_types) | Event types that will trigger this lambda | `set(string)` | <pre>[<br>  "CreateAccountResult",<br>  "InviteAccountToOrganization"<br>]</pre> | no |
+| <a name="input_lambda"></a> [lambda](#input\_lambda) | Map of any additional arguments for the upstream lambda module. See <https://github.com/terraform-aws-modules/terraform-aws-lambda> | `any` | `{}` | no |
 | <a name="input_log_level"></a> [log\_level](#input\_log\_level) | Log level of the lambda output, one of: debug, info, warning, error, critical | `string` | `"info"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags that are passed to resources | `map(string)` | `{}` | no |
 

--- a/tests/localstack.tf
+++ b/tests/localstack.tf
@@ -5,7 +5,7 @@ provider "aws" {
   skip_credentials_validation = true
   skip_metadata_api_check     = true
   skip_requesting_account_id  = true
-  s3_force_path_style         = true
+  s3_use_path_style           = true
 
   endpoints {
     cloudwatch       = "http://${var.localstack_host}:4566"

--- a/tests/test_create_all/main.tf
+++ b/tests/test_create_all/main.tf
@@ -1,0 +1,7 @@
+module "test_create_all" {
+  source = "../.."
+
+  cc_list            = "foo@example.com"
+  communication_body = "foo body"
+  subject            = "foo subject"
+}

--- a/tests/test_create_package_separately/main.tf
+++ b/tests/test_create_package_separately/main.tf
@@ -1,0 +1,24 @@
+module "test_create_package" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-lambda.git?ref=v4.1.1"
+
+  create_function = false
+  create_package  = true
+
+  recreate_missing_package = false
+
+  runtime     = "python3.8"
+  source_path = "${path.module}/../../lambda/src"
+}
+
+module "test_create_function" {
+  source = "../.."
+
+  cc_list            = "foo@example.com"
+  communication_body = "foo body"
+  subject            = "foo subject"
+
+  lambda = {
+    local_existing_package = "${path.module}/${module.test_create_package.local_filename}"
+    create_package         = false
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,20 @@ variable "communication_body" {
   type        = string
 }
 
+variable "event_types" {
+  description = "Event types that will trigger this lambda"
+  type        = set(string)
+  default = [
+    "CreateAccountResult",
+    "InviteAccountToOrganization",
+  ]
+
+  validation {
+    condition     = alltrue([for event in var.event_types : contains(["CreateAccountResult", "InviteAccountToOrganization"], event)])
+    error_message = "Supported event_types include only: CreateAccountResult, InviteAccountToOrganization"
+  }
+}
+
 variable "lambda" {
   description = "Map of any additional arguments for the upstream lambda module. See <https://github.com/terraform-aws-modules/terraform-aws-lambda>"
   type        = any

--- a/variables.tf
+++ b/variables.tf
@@ -2,15 +2,24 @@ variable "cc_list" {
   description = "Comma-separated list of email addresses to CC on this case.  At least one email address is required."
   type        = string
 }
+
 variable "communication_body" {
   description = "Text for body of the communication sent to support.  The variable 'account_id' can be used within the text if preceded by a dollar sign and optionally enclosed by curly braces."
   type        = string
 }
+
+variable "lambda" {
+  description = "Map of any additional arguments for the upstream lambda module. See <https://github.com/terraform-aws-modules/terraform-aws-lambda>"
+  type        = any
+  default     = {}
+}
+
 variable "log_level" {
   default     = "info"
   description = "Log level of the lambda output, one of: debug, info, warning, error, critical"
   type        = string
 }
+
 variable "subject" {
   description = "Text for 'Subject' field of the communication sent to support.  The variable 'account_id' can be used within the text if preceded by a dollar sign and optionally enclosed by curly braces."
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.9"
+    }
+    external = {
+      source  = "hashicorp/external"
+      version = ">= 1.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
+  }
+}


### PR DESCRIPTION
* Replaces claranet lambda module with terraform-aws-modules
* Creates simple terraform test configs to exercise the module
* Uses CreateAccountResult service event to eliminate lambda wait/loop
* Simplifies exception handling using excepthook handler